### PR TITLE
cleanup: rework exports

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -3,7 +3,7 @@ use criterion::{
     Throughput,
 };
 
-use fvm_wasm_instrument::{gas_metering, inject_stack_limiter};
+use fvm_wasm_instrument::{gas_metering, stack_limiter};
 
 use std::{
     fs::{read, read_dir},
@@ -44,7 +44,7 @@ fn gas_metering(c: &mut Criterion) {
 fn stack_height_limiter(c: &mut Criterion) {
     let mut group = c.benchmark_group("Stack Height Limiter");
     any_fixture(&mut group, |raw_wasm| {
-        inject_stack_limiter(raw_wasm, 128).unwrap();
+        stack_limiter::inject(raw_wasm, 128).unwrap();
     });
 }
 

--- a/src/gas_metering/mod.rs
+++ b/src/gas_metering/mod.rs
@@ -22,8 +22,11 @@ use wasm_encoder::{
 use wasmparser::{
     CodeSectionReader, DataKind, DataSectionReader, ElementItem, ElementSectionReader,
     ExportSectionReader, ExternalKind, FuncType, FunctionBody, FunctionSectionReader,
-    ImportSectionReader, Operator, SectionReader, Type, TypeRef, TypeSectionReader,
+    ImportSectionReader, SectionReader, Type, TypeRef, TypeSectionReader,
 };
+
+#[doc(inline)]
+pub use wasmparser::Operator;
 
 pub const GAS_COUNTER_NAME: &str = "gas_counter";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,5 @@ extern crate alloc;
 extern crate core;
 
 pub mod gas_metering;
-mod stack_limiter;
+pub mod stack_limiter;
 mod utils;
-
-pub use stack_limiter::inject as inject_stack_limiter;

--- a/src/stack_limiter/mod.rs
+++ b/src/stack_limiter/mod.rs
@@ -43,7 +43,7 @@ macro_rules! instrument_call {
 mod max_height;
 mod thunk;
 
-pub struct Context {
+struct Context {
     stack_height_global_idx: u32,
     func_stack_costs: Vec<u32>,
     stack_limit: u32,

--- a/src/stack_limiter/thunk.rs
+++ b/src/stack_limiter/thunk.rs
@@ -24,7 +24,7 @@ struct Thunk {
     callee_stack_cost: u32,
 }
 
-pub fn generate_thunks(ctx: &mut Context, module: &mut ModuleInfo) -> Result<()> {
+pub(super) fn generate_thunks(ctx: &mut Context, module: &mut ModuleInfo) -> Result<()> {
     // First, we need to collect all function indices that should be replaced by thunks
     let exports = match module.raw_sections.get(&SectionId::Export.into()) {
         Some(raw_sec) => ExportSectionReader::new(&raw_sec.data, 0)?

--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -1,4 +1,4 @@
-use fvm_wasm_instrument::{self as instrument};
+use fvm_wasm_instrument::{gas_metering, stack_limiter};
 use std::{
     fs,
     io::{self, Read, Write},
@@ -74,7 +74,7 @@ mod stack_height {
                 run_diff_test(
                     "stack-height",
                     concat!(stringify!($name), ".wat"),
-                    |input| instrument::inject_stack_limiter(input, 1024).unwrap(),
+                    |input| stack_limiter::inject(input, 1024).unwrap(),
                 );
             }
         };
@@ -97,8 +97,8 @@ mod gas {
             #[test]
             fn $name() {
                 run_diff_test("gas", concat!(stringify!($name), ".wat"), |input| {
-                    let rules = instrument::gas_metering::ConstantCostRules::default();
-                    instrument::gas_metering::inject(&input, &rules, "env").unwrap()
+                    let rules = gas_metering::ConstantCostRules::default();
+                    gas_metering::inject(&input, &rules, "env").unwrap()
                 });
             }
         };

--- a/tests/overhead.rs
+++ b/tests/overhead.rs
@@ -1,4 +1,4 @@
-use fvm_wasm_instrument::{gas_metering, inject_stack_limiter};
+use fvm_wasm_instrument::{gas_metering, stack_limiter};
 use std::{
     fs::{read, read_dir},
     path::PathBuf,
@@ -33,8 +33,8 @@ fn print_size_overhead() {
                 .unwrap();
                 (module.len(), module)
             };
-            let stack_height_len = inject_stack_limiter(&orig_module, 128).unwrap().len();
-            let both_len = inject_stack_limiter(&gas_module, 128).unwrap().len();
+            let stack_height_len = stack_limiter::inject(&orig_module, 128).unwrap().len();
+            let both_len = stack_limiter::inject(&gas_module, 128).unwrap().len();
 
             let overhead = both_len * 100 / orig_len;
             (


### PR DESCRIPTION
- Export stack_limiter module.
- Only export the inject methods and necessary types.
- Re-export the wasmparser::Operator.